### PR TITLE
Change event handler method name to _onEventName

### DIFF
--- a/src/util/template_function.ts
+++ b/src/util/template_function.ts
@@ -57,5 +57,5 @@ export function getEventHandlerTemplate(event: BlocEvent) {
 
 function getMethodName(event: BlocEvent){
   let eventClassName = event.sealedClass;
-  return `_map${eventClassName}ToState`;
+  return `_on${eventClassName}`;
 }


### PR DESCRIPTION
Closer in line with conventions in recent documentation [examples](https://bloclibrary.dev/#/fluttertimertutorial)